### PR TITLE
changed slf4j dependency to api instead of simple

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,10 +67,16 @@
 			<artifactId>bcprov-jdk15on</artifactId>
 			<version>1.70</version>
 		</dependency>
+			<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.7.25</version>
+		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
 			<version>1.7.25</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.zeromq</groupId>


### PR DESCRIPTION
According to https://www.slf4j.org/manual.html#libraries Embedded components such as libraries or frameworks should not declare a dependency on any SLF4J binding/provider but only depend on slf4j-api. 
This commit resolves the issue, and adds -simple back in the test scope.