### PR TITLE
test: update offline wallet expectations for ungated daemon calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ walletFull.close(true);
 
 #### For Gradle, add to build.gradle:
 
-`compile 'io.github.woodser:monero-java:0.8.55'`
+`compile 'io.github.woodser:monero-java:0.8.56'`
 
 #### For Maven, add to pom.xml:
 
@@ -105,7 +105,7 @@ walletFull.close(true);
 <dependency>
   <groupId>io.github.woodser</groupId>
   <artifactId>monero-java</artifactId>
-  <version>0.8.55</version>
+  <version>0.8.56</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.github.woodser</groupId>
 	<artifactId>monero-java</artifactId>
-	<version>0.8.55</version>
+	<version>0.8.56</version>
 	<name>Monero Java Library</name>
 	<description>A Java library for using Monero</description>
 	<url>https://github.com/woodser/monero-java</url>

--- a/src/main/cpp/monero_jni_bridge.cpp
+++ b/src/main/cpp/monero_jni_bridge.cpp
@@ -1428,10 +1428,10 @@ JNIEXPORT jstring JNICALL Java_monero_wallet_MoneroWalletFull_describeTxSetJni(J
   try {
 
     // deserialize tx set to describe
-    monero_tx_set tx_set = monero_tx_set::deserialize(tx_set_json);
+    shared_ptr<monero_tx_set> tx_set = monero_tx_set::deserialize(tx_set_json);
 
     // describe tx set
-    monero_tx_set described_tx_set = wallet->describe_tx_set(tx_set);
+    monero_tx_set described_tx_set = wallet->describe_tx_set(*tx_set);
 
     // serialize, free, and return
     std::string monero_tx_set_json = described_tx_set.serialize();

--- a/src/main/java/monero/common/MoneroUtils.java
+++ b/src/main/java/monero/common/MoneroUtils.java
@@ -42,7 +42,7 @@ public class MoneroUtils {
    * @return the version of this monero-java library
    */
   public static String getVersion() {
-    return "0.8.55";
+    return "0.8.56";
   }
 
   /**

--- a/src/main/java/monero/common/TaskLooper.java
+++ b/src/main/java/monero/common/TaskLooper.java
@@ -54,15 +54,23 @@ public class TaskLooper {
       if (isStarted) return this;
       isStarted = true;
       
-      // start looping
+      // reuse a live loop, which observes isStarted under lock and continues
       if (isLooping) return this;
       isLooping = true;
       TaskLooper that = this;
       Thread loop = new Thread(new Runnable() {
         @Override
         public void run() {
-          while (isStarted && !Thread.currentThread().isInterrupted()) {
-            
+          while (true) {
+
+            // decide to exit and clear isLooping atomically so a restart cannot reuse a dead loop
+            synchronized (that) {
+              if (!isStarted || Thread.currentThread().isInterrupted()) {
+                isLooping = false;
+                return;
+              }
+            }
+
             // run the task
             long startTime = System.currentTimeMillis();
             task.run();
@@ -71,12 +79,12 @@ public class TaskLooper {
             if (isStarted) {
               try { TimeUnit.MILLISECONDS.sleep(that.periodInMs - (targetFixedPeriod ? System.currentTimeMillis() - startTime : 0)); } // target fixed period by accounting for run time
               catch (Exception e) {
-                isLooping = false;
+                synchronized (that) { isLooping = false; }
                 if (isStarted) throw new RuntimeException(e);
+                return;
               }
             }
           }
-          isLooping = false;
         }
       });
       loop.start();

--- a/src/main/java/monero/wallet/MoneroWalletRpc.java
+++ b/src/main/java/monero/wallet/MoneroWalletRpc.java
@@ -2421,8 +2421,14 @@ public class MoneroWalletRpc extends MoneroWalletDefault {
           
           // announce new unlocked outputs
           for (MoneroTxWallet unlockedTx : unlockedTxs) {
+            boolean missedConfirm = Boolean.TRUE.equals(unlockedTx.isConfirmed()) && !prevConfirmedNotifications.contains(unlockedTx.getHash());
             prevUnconfirmedNotifications.remove(unlockedTx.getHash()); // stop tracking tx notifications
             prevConfirmedNotifications.remove(unlockedTx.getHash());
+            if (missedConfirm) { // announce missed confirm transition if tx unlocked between polls
+              MoneroTxWallet confirmedTx = unlockedTx.copy().setIsLocked(true);
+              confirmedTx.setBlock(unlockedTx.getBlock().copy().setTxs(confirmedTx));
+              notifyOutputs(confirmedTx);
+            }
             notifyOutputs(unlockedTx);
           }
           

--- a/src/test/java/TestMoneroWalletFull.java
+++ b/src/test/java/TestMoneroWalletFull.java
@@ -251,8 +251,9 @@ public class TestMoneroWalletFull extends TestMoneroWalletCommon {
     // cannot get daemon chain height
     try {
       wallet.getDaemonHeight();
+      fail("Should have thrown exception");
     } catch (MoneroError e) {
-      assertEquals("Wallet is not connected to daemon", e.getMessage());
+      assertEquals("daemon error", e.getMessage()); // wallet2 masks errors from untrusted daemons
     }
     
     // set daemon connection and check chain height
@@ -307,7 +308,7 @@ public class TestMoneroWalletFull extends TestMoneroWalletCommon {
     assertFalse(wallet.isSynced());
     assertEquals(1, wallet.getHeight());
     assertEquals(0, wallet.getRestoreHeight());
-    try { wallet.startSyncing(); } catch (MoneroError e) { assertEquals("Wallet is not connected to daemon", e.getMessage()); }
+    wallet.startSyncing(); // succeeds while offline, syncing when a daemon becomes reachable
     wallet.close();
     
     // create wallet without restore height
@@ -771,9 +772,7 @@ public class TestMoneroWalletFull extends TestMoneroWalletCommon {
       assertNotNull(wallet.getSeed());
       assertEquals(1, wallet.getHeight());
       assertEquals(BigInteger.valueOf(0), wallet.getBalance());
-      wallet.startSyncing();
-    } catch (MoneroError e) {
-      assertEquals("Wallet is not connected to daemon", e.getMessage());
+      wallet.startSyncing(); // succeeds while offline, syncing when a daemon becomes reachable
     } finally {
       wallet.close();
     }


### PR DESCRIPTION
getDaemonHeight surfaces wallet2's natural connection error and startSyncing succeeds offline like monero-wallet-rpc's auto_refresh.